### PR TITLE
Bugfix while merging arrays

### DIFF
--- a/SchedulerShell.php
+++ b/SchedulerShell.php
@@ -76,7 +76,7 @@ class SchedulerShell extends AppShell{
 			// read in the jobs from the config
 			if(isset($config['jobs'])){
 				foreach($config['jobs'] as $k=>$v){
-					$v = array('action'=>'execute', 'pass'=>array()) + $v;
+					$v = $v + array('action'=>'execute', 'pass'=>array());
 					$this->connect($k, $v['interval'], $v['task'], $v['action'], $v['pass']);
 				}
 			}


### PR DESCRIPTION
'pass' => array() isn't copied if the $v is not on the left side.
