### PR TITLE
Prevent simultaneous SchedulerShells from running

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ Configure::write('SchedulerShell.storeFile', "scheduler_results.json");
 Configure::write('SchedulerShell.storePath', "/path/to/save/");
 ```
 
+Preventing Simultaneous SchedulerShells Running Same Tasks
+----------------------------------------------------------
+By default, the SchedulerShell will exit if it is already running and has been for less than 10 minutes. You can adjust this by setting:
+
+```php
+// change the number of seconds to wait before running a parallel SchedulerShell; 0 = do not exit
+Configure::write('SchedulerShell.processTimeout', 5*60);
+```
 
 Other Notes/Known Issues
 ------------------------


### PR DESCRIPTION
There may be some situations where a SchedulerShell is running a task which takes longer to execute than the amount of time between a new SchedulerShell being launched by your cron job. This will prevent the SchedulerShell starting again on the same task.

It can be disabled or adjusted with a configure setting.
