### PR TITLE
Remove require composer/installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ Author
 ------
 Trent Richardson [http://trentrichardson.com]
 
-Developed as part of the CarBounce project [http://carbounce.com]
-
 License
 -------
 Copyright 2015 Trent Richardson
@@ -42,13 +40,13 @@ Copy the Scheduler plugin into your App/Plugin folder and rename the folder to S
 In your bootstrap.php file add either:
 
 ```php
-CakePlugin::loadAll();
+Plugin::loadAll();
 ```
 
 or
 
 ```php
-CakePlugin::load('Scheduler',['autoload'=>true]);
+Plugin::load('Scheduler',['autoload'=>true]);
 ```
 
 Schedule a single system cron by the shortest interval you need for SchedulerShell.php.  For example, if you have 5 tasks and the most often run is every 5 minutes, then schedule this cron to run at least every 5 minutes. For more help see [Shells as Cron Jobs](http://book.cakephp.org/2.0/en/console-and-shells/cron-jobs.html).

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Now once this shell is scheduled we are able to add our entries to bootstrap.php
 ```php
 Configure::write('SchedulerShell.jobs', array(
 	'CleanUp' => array('interval' => 'next day 5:00', 'task' => 'CleanUp'),// tomorrow at 5am
-	'Newsletters' => array('interval' => 'PT15M', 'task' => 'Newsletter') //every 15 minutes
+	'Newsletters' => array('interval' => 'PT15I', 'task' => 'Newsletter') //every 15 minutes
 ));
 ```
 
@@ -73,7 +73,7 @@ The key to each entry will be used to store the previous run.  *These must be un
 **interval** is set one of two ways.
 1) For set times of day we use PHP's [relative time formats](http://www.php.net/manual/en/datetime.formats.relative.php): "next day 5:00".
 
-2) To use an interval to achieve "every 15 minutes" we use [DateInterval](http://www.php.net/manual/en/class.dateinterval.php) string format: "PT15M".
+2) To use an interval to achieve "every 15 minutes" we use [DateInterval](http://www.php.net/manual/en/class.dateinterval.php) string format: "PT15I".
 
 **task** is simply the name of the Task.
 
@@ -86,7 +86,7 @@ There are a couple optional arguments you may pass: "action" and "pass".
 ```php
 Configure::write('SchedulerShell.jobs', array(
 	'CleanUp' => array('interval' => 'next day 5:00', 'task' => 'CleanUp', 'action' => 'execute', 'pass' => array()),
-	'Newsletters' => array('interval' => 'PT15M', 'task' => 'Newsletter', 'action' => 'execute', 'pass' => array())
+	'Newsletters' => array('interval' => 'PT15I', 'task' => 'Newsletter', 'action' => 'execute', 'pass' => array())
 ));
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,7 @@
 	    }
 	},
 	"require": {
-		"php": ">=5.3.6",
-		"composer/installers": "*"
+		"php": ">=5.3.6"
 	},
 	"support": {
 		"source": "https://github.com/trentrichardson/cakephp-scheduler"

--- a/src/Shell/SchedulerShell.php
+++ b/src/Shell/SchedulerShell.php
@@ -229,6 +229,10 @@ class SchedulerShell extends Shell{
 				// assign it the current time
 				$now = new DateTime();
 				$store[$name]['lastRun'] = $now->format('Y-m-d H:i:s');
+			} else {
+				$this->hr();
+				$this->out("Not time to run $name, skipping.");
+				$this->hr();
 			}
 		}
 

--- a/src/Shell/SchedulerShell.php
+++ b/src/Shell/SchedulerShell.php
@@ -9,7 +9,11 @@
  *
  * -------------------------------------------------------------------
  * To configure:
- * In your bootstrap.php you must add your jobs:
+ * In your bootstrap_cli.php you must enable the plugin:
+ *
+ * Plugin::load('Scheduler');
+ *
+ * Then in bootstrap_cli.php schedule your jobs:
  *
  * Configure::write('SchedulerShell.jobs', array(
  * 	'CleanUp' => array('interval'=>'next day 5:00','task'=>'CleanUp'),// tomorrow at 5am
@@ -17,21 +21,16 @@
  * ));
  *
  * -------------------------------------------------------------------
- * Add cake to $PATH:
- * - edit .bashrc (linux) or .bash_profile (mac) and add
- * - export PATH="/path/to/cakephp/lib/Cake/Console:$PATH"
- * - reload with:
- * 	>> source .bashrc
- *
- * -------------------------------------------------------------------
  * Run a shell task:
  * - Cd into app dir
  * - run this:
- * 	>> Console/cake Scheduler.Scheduler
+ * 	>> bin/cake Scheduler.Scheduler
  *
  * -------------------------------------------------------------------
  * Troubleshooting
- * - may have to run dos2unix to fix line endings in the Config/cake file
+ * - may have to run dos2unix to fix line endings in the bin/cake file
+ * - if you didn't use composer to install this plugin you may need to 
+ *   enable the plugin with Plugin::load('Scheduler', [ 'autoload'=>true ]);
  */
 namespace Scheduler\Shell;
 


### PR DESCRIPTION
This installer make error when integrate plugin: `https://github.com/dereuromark/cakephp-tinyauth`
Use default plugin-install of CakePHP 3 instead.
Solution: Remove line 15 in 'composer.json'

```
"composer/installers": "*"
```

Error here: https://github.com/dereuromark/cakephp-tinyauth/issues/17
